### PR TITLE
Re-align Pardot Form

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -7,7 +7,7 @@ html {
 }
 
 body {
-    font-family: "helvetica neue" !important;
+    font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
     color: white;
 }
 

--- a/index.html
+++ b/index.html
@@ -71,7 +71,8 @@
         </div>
     </div>
     <div class="row">
-        <div class="ten columns">
+        <div class="three columns">&nbsp;</div>
+        <div class="six columns">
             <iframe src="http://go.docker.com/l/44082/2015-02-18/3d3yp" width="100%" height="500" type="text/html" frameborder="0" allowTransparency="true" style="border: 0"></iframe>
         </div>
     </div>


### PR DESCRIPTION
Fixes mobile layout by introducing a spacer div and reducing `columns`
to roughly match the width set in the Pardot form layout. (I changed the
styles in Pardot as well to remove the `position`ing)

Also sets some fallbacks for the fonts.

Signed-off-by: Chris Biscardi chris@docker.com
