### PR TITLE
update link to doc walkthrough

### DIFF
--- a/content/contributing/docs.md
+++ b/content/contributing/docs.md
@@ -62,7 +62,7 @@ target="_blank">Github account</a>.
 # Write new or update existing documentation
 
 Writing documentation requires you to fork the Docker repo and write source
-using Markdown code.  We have a <a href="http://docs.docker.com/project">guide
+using Markdown code.  We have a <a href="http://docs.docker.com/project/who-written-for/">guide
 that walks you through the entire process</a>.
 
 You can check our list of <a href="http://goo.gl/eCfY69"


### PR DESCRIPTION
Thanks to @fredlf for pointing out -- it looks like this link should go here to the walkthrough instead of the project list.
